### PR TITLE
Fixing "String RoboteqSerial::readQuery" for RX availability

### DIFF
--- a/src/RoboteqSerial.cpp
+++ b/src/RoboteqSerial.cpp
@@ -1110,13 +1110,16 @@ String RoboteqSerial::readQuery(const char *message)
 {
     String inputString;
     unsigned long startTime = millis();
-    while (millis() - startTime < _timeout && _stream.available())
+    while (millis() - startTime < _timeout)
     {
-        inputString = _stream.readStringUntil('\r');
-
-        if (inputString.startsWith(message))
+        if(_stream.available())
         {
-            return inputString.substring(inputString.indexOf("=") + 1);
+            inputString = _stream.readStringUntil('\r');
+
+            if (inputString.startsWith(message))
+            {
+                return inputString.substring(inputString.indexOf("=") + 1);
+            }
         }
     }
     return "-1";


### PR DESCRIPTION
Method "String RoboteqSerial::readQuery(const char *message)" expects, on top of the timeout, that RX is available. That's OK, but in cases where the processor used is fast (like ESP32) the Roboteq controller may have not replied yet when readQuery is called after a "sendQuery". So, the _stream.available() should be inside the while.